### PR TITLE
Replace blocking sleeps with cancellable delays

### DIFF
--- a/AdvancedSeedPhraseFinder.cs
+++ b/AdvancedSeedPhraseFinder.cs
@@ -1104,7 +1104,7 @@ namespace BitcoinFinder
             Console.WriteLine($"Тест 3 (частичный): {(completed3 && progressCount3 > 0 && lastProgress3 > BigInteger.Zero ? "ПРОШЕЛ" : "НЕ ПРОШЕЛ")}");
         }
 
-        public void TestSpeedCalculation()
+        public async Task TestSpeedCalculationAsync(CancellationToken token)
         {
             speedHistory.Clear();
             BigInteger fakeTotal = 1000000;
@@ -1149,7 +1149,7 @@ namespace BitcoinFinder
                 var remaining = TimeSpan.FromSeconds(secondsLeft);
                 string speedStr = displaySpeed < 0 ? "нереально" : (displaySpeed < 1 ? "очень медленно" : displaySpeed.ToString("N0"));
                 Console.WriteLine($"Шаг {i+1,2}: Прогресс: {fakeCurrent:N0} / {fakeTotal:N0} | Скорость: {speedStr}/сек | Осталось: {(displaySpeed > 0 ? remaining.ToString() : "-")}");
-                Thread.Sleep((i % 7 == 0) ? 800 : 200); // иногда задержка
+                await Task.Delay((i % 7 == 0) ? 800 : 200, token); // иногда задержка
             }
             Console.WriteLine("Тест завершён.");
         }

--- a/Form1.cs
+++ b/Form1.cs
@@ -1260,7 +1260,7 @@ namespace BitcoinFinder
                 btnAgentConnect.Text = "Подключиться";
             }
         }
-        private void AgentWorker(string ip, int port, CancellationToken token)
+        private async Task AgentWorker(string ip, int port, CancellationToken token)
         {
             while (!token.IsCancellationRequested)
             {
@@ -1289,14 +1289,14 @@ namespace BitcoinFinder
                             if (msg == null || !msg.ContainsKey("command"))
                             {
                                 this.Invoke(new Action(() => lblAgentStatus.Text = "Статус: Некорректный ответ сервера"));
-                                Thread.Sleep(5000);
+                                await Task.Delay(5000, token);
                                 continue;
                             }
                             string cmd = msg["command"].ToString();
                             if (cmd == "NO_TASK")
                             {
                                 this.Invoke(new Action(() => lblAgentStatus.Text = "Статус: Нет заданий, жду..."));
-                                Thread.Sleep(10000);
+                                await Task.Delay(10000, token);
                                 continue;
                             }
                             if (cmd == "TASK")
@@ -1394,7 +1394,7 @@ namespace BitcoinFinder
                     btnAgentConnect.Text = "Подключиться";
                 }));
                 if (!token.IsCancellationRequested)
-                    Thread.Sleep(5000);
+                    await Task.Delay(5000, token);
             }
         }
 


### PR DESCRIPTION
## Summary
- use async Task delay in `AgentWorker`
- allow cancellation in `TestSpeedCalculation` demo method

## Testing
- `dotnet build BitcoinFinder.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f651ace4c832c9e33fbe6543825e0