### PR TITLE
Optimize AgentWorker word list generation

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -1326,11 +1326,16 @@ namespace BitcoinFinder
                                 }
 
                                 int reportInterval = agentClient.ProgressReportInterval; // из конфигурации
+
+                                // Создаём массив возможных слов один раз для всего блока
+                                var possibleWords = new List<string>[wordCount];
+                                for (int w = 0; w < wordCount; w++)
+                                    possibleWords[w] = finder.GetBip39Words();
+
                                 for (long i = startIndex; i <= endIndex && !token.IsCancellationRequested; i++)
                                 {
                                     // Генерируем seed-фразу по индексу
-                                    var possibleWords = new List<string>[wordCount];
-                                    for (int w = 0; w < wordCount; w++) possibleWords[w] = finder.GetBip39Words();
+                                    // combination рассчитывается на основе заранее подготовленного possibleWords
                                     var combination = finder.GenerateCombinationByIndex(new System.Numerics.BigInteger(i), possibleWords);
                                     var seedPhrase = string.Join(" ", combination);
                                     string wif = null;


### PR DESCRIPTION
## Summary
- reuse `possibleWords` array across iterations in AgentWorker

## Testing
- `bash dotnet-install.sh --version 8.0.100`
- `dotnet build` *(fails: NETSDK1100)*

------
https://chatgpt.com/codex/tasks/task_e_686f66bd42f0832c87afbe32865ab3d8