### PR TITLE
Add distributed coordinator server and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+dotnet-install.sh

--- a/DistributedCoordinatorServer.cs
+++ b/DistributedCoordinatorServer.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BitcoinFinder.Distributed;
+
+namespace BitcoinFinder
+{
+    public class DistributedCoordinatorServer
+    {
+        private readonly int _port;
+        private TcpListener? _listener;
+
+        public ConcurrentQueue<BlockTask> PendingTasks { get; } = new ConcurrentQueue<BlockTask>();
+        public ConcurrentDictionary<string, AgentInfo> ConnectedAgents { get; } = new ConcurrentDictionary<string, AgentInfo>();
+
+        public DistributedCoordinatorServer(int port = 5000)
+        {
+            _port = port;
+        }
+
+        public async Task StartServerAsync(CancellationToken token = default)
+        {
+            _listener = new TcpListener(IPAddress.Any, _port);
+            _listener.Start();
+            Console.WriteLine($"[SERVER] Started on port {_port}");
+
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    var client = await _listener.AcceptTcpClientAsync(token);
+                    _ = HandleClientAsync(client);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // graceful shutdown
+            }
+            catch (ObjectDisposedException)
+            {
+                // listener stopped
+            }
+        }
+
+        public void StopServer()
+        {
+            _listener?.Stop();
+        }
+
+        private async Task HandleClientAsync(TcpClient client)
+        {
+            using (client)
+            {
+                var endpoint = client.Client.RemoteEndPoint?.ToString() ?? "unknown";
+                Console.WriteLine($"[SERVER] Client connected {endpoint}");
+                using var stream = client.GetStream();
+                using var reader = new StreamReader(stream, Encoding.UTF8);
+                using var writer = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
+
+                while (client.Connected)
+                {
+                    string? line;
+                    try
+                    {
+                        line = await reader.ReadLineAsync();
+                    }
+                    catch
+                    {
+                        break;
+                    }
+
+                    if (line == null) break;
+                    if (string.IsNullOrWhiteSpace(line)) continue;
+
+                    Message msg;
+                    try
+                    {
+                        msg = Message.FromJson(line);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"[SERVER] Invalid message: {ex.Message}");
+                        continue;
+                    }
+
+                    var response = await ProcessMessageAsync(msg, endpoint);
+                    if (response != null)
+                    {
+                        await writer.WriteLineAsync(response.ToJson());
+                    }
+                }
+            }
+        }
+
+        private async Task<Message?> ProcessMessageAsync(Message msg, string ip)
+        {
+            switch (msg.Type)
+            {
+                case MessageType.AGENT_REGISTER:
+                    var agent = new AgentInfo
+                    {
+                        AgentId = msg.AgentId,
+                        IpAddress = ip,
+                        Status = "Idle",
+                        LastHeartbeat = DateTime.UtcNow
+                    };
+                    ConnectedAgents[msg.AgentId] = agent;
+                    Console.WriteLine($"[SERVER] Registered agent {msg.AgentId}");
+                    return new Message
+                    {
+                        Type = MessageType.AGENT_REGISTER,
+                        AgentId = msg.AgentId,
+                        Data = JsonSerializer.SerializeToElement(new { status = "OK" }),
+                        Timestamp = DateTime.UtcNow
+                    };
+
+                case MessageType.AGENT_REQUEST_TASK:
+                    if (PendingTasks.TryDequeue(out var task))
+                    {
+                        task.AssignedToAgent = msg.AgentId;
+                        agent = ConnectedAgents[msg.AgentId];
+                        agent.CurrentBlockId = task.BlockId;
+                        ConnectedAgents[msg.AgentId] = agent;
+                        return new Message
+                        {
+                            Type = MessageType.SERVER_TASK_ASSIGNED,
+                            AgentId = msg.AgentId,
+                            Data = JsonSerializer.SerializeToElement(task),
+                            Timestamp = DateTime.UtcNow
+                        };
+                    }
+                    else
+                    {
+                        return new Message
+                        {
+                            Type = MessageType.SERVER_NO_TASKS,
+                            AgentId = msg.AgentId,
+                            Timestamp = DateTime.UtcNow
+                        };
+                    }
+            }
+            await Task.Yield();
+            return null;
+        }
+
+        public void CreateTask(int blockId, long start, long end)
+        {
+            var task = new BlockTask
+            {
+                BlockId = blockId,
+                StartIndex = start,
+                EndIndex = end,
+                Status = "Pending"
+            };
+            PendingTasks.Enqueue(task);
+        }
+    }
+}

--- a/DistributedProtocolTests/CoordinatorServerTests.cs
+++ b/DistributedProtocolTests/CoordinatorServerTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BitcoinFinder;
+using BitcoinFinder.Distributed;
+using Xunit;
+
+namespace DistributedProtocolTests;
+
+public class CoordinatorServerTests
+{
+    [Fact]
+    public async Task ServerStartsAndRegistersAgent()
+    {
+        var server = new DistributedCoordinatorServer(5000);
+        using var cts = new CancellationTokenSource();
+        var serverTask = server.StartServerAsync(cts.Token);
+
+        await Task.Delay(200); // allow server to start
+        server.CreateTask(1, 0, 100);
+
+        using var client = new TcpClient();
+        await client.ConnectAsync("127.0.0.1", 5000);
+
+        using var stream = client.GetStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        using var writer = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
+
+        var register = new Message
+        {
+            Type = MessageType.AGENT_REGISTER,
+            AgentId = "test-agent",
+            Timestamp = DateTime.UtcNow
+        };
+        await writer.WriteLineAsync(register.ToJson());
+        var respLine = await reader.ReadLineAsync();
+        Assert.NotNull(respLine);
+        var resp = Message.FromJson(respLine!);
+        Assert.Equal(MessageType.AGENT_REGISTER, resp.Type);
+
+        // clean up
+        cts.Cancel();
+        server.StopServer();
+        await serverTask;
+
+        Assert.True(server.ConnectedAgents.ContainsKey("test-agent"));
+        Console.WriteLine("SERVER TEST PASSED");
+    }
+}

--- a/DistributedProtocolTests/DistributedProtocolTests.csproj
+++ b/DistributedProtocolTests/DistributedProtocolTests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <Compile Include="../DistributedProtocol.cs" Link="DistributedProtocol.cs" />
+    <Compile Include="../DistributedCoordinatorServer.cs" Link="DistributedCoordinatorServer.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add `DistributedCoordinatorServer` for managing agents via TCP
- add basic handshake test `CoordinatorServerTests`
- include server source in test project
- ignore `dotnet-install.sh`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686f7b9e0074832cac1ca57154861d9a