### PR TITLE
Add client workflow methods and tests

### DIFF
--- a/DistributedProtocolTests/AgentClientTests.cs
+++ b/DistributedProtocolTests/AgentClientTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BitcoinFinder;
+using BitcoinFinder.Distributed;
+using Xunit;
+
+namespace DistributedProtocolTests;
+
+public class AgentClientTests
+{
+    [Fact]
+    public async Task ClientWorkflowSuccess()
+    {
+        var server = new DistributedCoordinatorServer(5001);
+        using var cts = new CancellationTokenSource();
+        var serverTask = server.StartServerAsync(cts.Token);
+        await Task.Delay(200);
+        server.CreateTask(1, 0, 5);
+
+        var client = new DistributedAgentClient();
+        Assert.True(await client.ConnectToServer("127.0.0.1", 5001));
+        await client.SendRegisterMessage("agent1");
+        var registerResp = await client.ReceiveMessage();
+        Assert.NotNull(registerResp);
+        Assert.Equal(MessageType.AGENT_REGISTER, registerResp!.Type);
+
+        await client.RequestTask("agent1");
+        var task = await client.ReceiveTask();
+        Assert.NotNull(task);
+        await client.ProcessTestBlock(task!);
+
+        cts.Cancel();
+        server.StopServer();
+        await serverTask;
+        Console.WriteLine("CLIENT TEST PASSED");
+    }
+
+    [Fact]
+    public async Task ClientConnectionFailure()
+    {
+        var client = new DistributedAgentClient();
+        bool connected = await client.ConnectToServer("127.0.0.1", 5999);
+        Assert.False(connected);
+    }
+}

--- a/DistributedProtocolTests/DistributedProtocolTests.csproj
+++ b/DistributedProtocolTests/DistributedProtocolTests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="../DistributedProtocol.cs" Link="DistributedProtocol.cs" />
     <Compile Include="../DistributedCoordinatorServer.cs" Link="DistributedCoordinatorServer.cs" />
+    <Compile Include="../DistributedAgentClient.cs" Link="DistributedAgentClient.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- extend DistributedAgentClient with connection/message helpers
- add a simple test block processor
- create xUnit tests for agent client workflow
- include DistributedAgentClient in test project

## Testing
- `dotnet restore`
- `dotnet test --logger "console;verbosity=detailed"`

------
https://chatgpt.com/codex/tasks/task_e_686f7d7ec440832cb8d5d83b20c29651