### PR TITLE
Add WebMonitor HTTP service

### DIFF
--- a/DistributedProtocolTests/DistributedProtocolTests.csproj
+++ b/DistributedProtocolTests/DistributedProtocolTests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="../DistributedProtocol.cs" Link="DistributedProtocol.cs" />
     <Compile Include="../DistributedCoordinatorServer.cs" Link="DistributedCoordinatorServer.cs" />
     <Compile Include="../DistributedAgentClient.cs" Link="DistributedAgentClient.cs" />
+    <Compile Include="../WebMonitorService.cs" Link="WebMonitorService.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DistributedProtocolTests/WebMonitorTests.cs
+++ b/DistributedProtocolTests/WebMonitorTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BitcoinFinder;
+using Xunit;
+
+namespace DistributedProtocolTests;
+
+public class WebMonitorTests
+{
+    [Fact]
+    public async Task ServerProvidesStatusAndHtml()
+    {
+        var coord = new DistributedCoordinatorServer(5090);
+        var web = new WebMonitorService(coord);
+        using var cts = new CancellationTokenSource();
+        var task = web.StartAsync(cts.Token);
+
+        await Task.Delay(200);
+
+        using var client = new HttpClient();
+        string baseUrl = "http://localhost:8080";
+        var html = await client.GetStringAsync(baseUrl + "/");
+        Assert.Contains("Server Status: Running", html);
+
+        var jsonStr = await client.GetStringAsync(baseUrl + "/api/status");
+        using var doc = JsonDocument.Parse(jsonStr);
+        Assert.True(doc.RootElement.TryGetProperty("UptimeSeconds", out _));
+
+        cts.Cancel();
+        await task;
+
+        Console.WriteLine("WEB SERVER TEST PASSED");
+    }
+}

--- a/WebMonitorService.cs
+++ b/WebMonitorService.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BitcoinFinder
+{
+    public class WebMonitorService
+    {
+        private readonly HttpListener _listener = new HttpListener();
+        private readonly DistributedCoordinatorServer _coordinator;
+        private DateTime _startTime;
+
+        public WebMonitorService(DistributedCoordinatorServer coordinator, int port = 8080)
+        {
+            _coordinator = coordinator;
+            _listener.Prefixes.Add($"http://*:{port}/");
+        }
+
+        public async Task StartAsync(CancellationToken token = default)
+        {
+            _startTime = DateTime.UtcNow;
+            _listener.Start();
+            Console.WriteLine("[WEB] Listening on port 8080");
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    var context = await _listener.GetContextAsync();
+                    _ = Task.Run(() => ProcessRequest(context));
+                }
+            }
+            catch (HttpListenerException)
+            {
+                // listener stopped
+            }
+            finally
+            {
+                _listener.Stop();
+            }
+        }
+
+        private async Task ProcessRequest(HttpListenerContext context)
+        {
+            var path = context.Request.Url?.AbsolutePath.ToLowerInvariant() ?? "/";
+
+            switch (path)
+            {
+                case "/":
+                    await RespondHtml(context, "<html><body><h1>Server Status: Running</h1></body></html>");
+                    break;
+                case "/api/agents":
+                    await RespondJson(context, _coordinator.ConnectedAgents.Values);
+                    break;
+                case "/api/tasks":
+                    await RespondJson(context, _coordinator.PendingTasks.ToArray());
+                    break;
+                case "/api/status":
+                    var status = new
+                    {
+                        UptimeSeconds = (DateTime.UtcNow - _startTime).TotalSeconds,
+                        Agents = _coordinator.ConnectedAgents.Count,
+                        Tasks = _coordinator.PendingTasks.Count
+                    };
+                    await RespondJson(context, status);
+                    break;
+                default:
+                    context.Response.StatusCode = 404;
+                    context.Response.Close();
+                    break;
+            }
+        }
+
+        private static async Task RespondHtml(HttpListenerContext ctx, string html)
+        {
+            var bytes = Encoding.UTF8.GetBytes(html);
+            ctx.Response.ContentType = "text/html";
+            ctx.Response.ContentLength64 = bytes.Length;
+            await ctx.Response.OutputStream.WriteAsync(bytes);
+            ctx.Response.Close();
+        }
+
+        private static async Task RespondJson(HttpListenerContext ctx, object data)
+        {
+            var json = JsonSerializer.Serialize(data);
+            var bytes = Encoding.UTF8.GetBytes(json);
+            ctx.Response.ContentType = "application/json";
+            ctx.Response.ContentLength64 = bytes.Length;
+            await ctx.Response.OutputStream.WriteAsync(bytes);
+            ctx.Response.Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `WebMonitorService` for simple HTTP monitoring
- expose `/`, `/api/agents`, `/api/tasks`, and `/api/status` endpoints
- add `WebMonitorTests` to verify the server
- include new service file in test project

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f80199988832c973e6b46d8e0e40a